### PR TITLE
Fix path, only master novnc_tokens script has the -f option

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -82,7 +82,7 @@ install_proxy () {
   chkconfig websockify on
 
   # noVNC tokens script
-  wget https://raw.githubusercontent.com/abiquo/noVNC/xml-for-3.0/novnc_tokens.rb \
+  wget https://raw.githubusercontent.com/abiquo/noVNC/master/novnc_tokens.rb \
     -O /opt/websockify/novnc_tokens.rb
   chmod +x /opt/websockify/novnc_tokens.rb
 


### PR DESCRIPTION
It should download novnc_tokens from master as it is the version with the -f parameter, the one its downloading lacks of it, so the when the script is being run from cronjob fails